### PR TITLE
Update to pinned version of taxii module

### DIFF
--- a/layers/exporters/matrix_gen.py
+++ b/layers/exporters/matrix_gen.py
@@ -1,5 +1,5 @@
 from stix2 import TAXIICollectionSource, Filter, MemoryStore
-from taxii2client import Server, Collection
+from taxii2client.v20 import Server, Collection
 
 
 class DomainNotLoadedError(Exception):


### PR DESCRIPTION
Quick patch to make sure the taxii module still works within the matrix_gen code in spite of the recent updates.