### PR TITLE
Default Score for techniques patch

### DIFF
--- a/layers/exporters/matrix_gen.py
+++ b/layers/exporters/matrix_gen.py
@@ -11,6 +11,7 @@ class MatrixEntry:
             self.id = id
         if name is not None:
             self.name = name
+        self.score = None
 
     @property
     def id(self):

--- a/scripts/diff_stix.py
+++ b/scripts/diff_stix.py
@@ -484,8 +484,8 @@ class DiffStix(object):
             # build layer structure
             layer_json = {
                 "versions": {
-                    "layer": "4.0",
-                    "navigator": "4.0"
+                    "layer": "4.1",
+                    "navigator": "4.1"
                 },
                 "name": f"{thedate} {domainToDomainLabel[domain]} Updates",
                 "description": f"{domainToDomainLabel[domain]} updates for the {thedate} release of ATT&CK",

--- a/scripts/layers/samples/apt3_apt29_software.py
+++ b/scripts/layers/samples/apt3_apt29_software.py
@@ -118,8 +118,8 @@ def generate(show_nodetect=False):
     return {
         "name": name,
         "versions": {
-            "layer": "4.0",
-            "navigator": "4.0"
+            "layer": "4.1",
+            "navigator": "4.1"
         },
         "description": description,
         "domain": "enterprise-attack",

--- a/scripts/layers/samples/bear_APT.py
+++ b/scripts/layers/samples/bear_APT.py
@@ -63,8 +63,8 @@ def generate():
     return {
         "name": "*Bear APTs",
         "versions": {
-            "layer": "4.0",
-            "navigator": "4.0"
+            "layer": "4.1",
+            "navigator": "4.1"
         },
         "description": "All techniques used by an APT group with phrase 'bear' in the group aliases",
         "domain": "enterprise-attack",

--- a/scripts/layers/samples/heatmap.py
+++ b/scripts/layers/samples/heatmap.py
@@ -27,8 +27,8 @@ def generate():
     return {
         "name": "heatmap example",
         "versions": {
-            "layer": "4.0",
-            "navigator": "4.0"
+            "layer": "4.1",
+            "navigator": "4.1"
         },
         "sorting": 3, # descending order of score
         "description": "An example layer where all techniques have a randomized score",

--- a/scripts/layers/samples/software_execution.py
+++ b/scripts/layers/samples/software_execution.py
@@ -69,8 +69,8 @@ def generate(softwaretype="software"):
         "name": layername,
         "description": layerdescription,
         "versions": {
-            "layer": "4.0",
-            "navigator": "4.0"
+            "layer": "4.1",
+            "navigator": "4.1"
         },
         "domain": "enterprise-attack",
         "techniques": techniques_list,


### PR DESCRIPTION
Minor patch to introduce a default score to prevent possible referencing issues - the score is still unset until the value is set as normal, but now referencing it before that point doesn't cause a crash.