### PR TITLE
Layer Object Import Shenanigans Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.9.0 - 23 March 2021
+## Fixes
+- Fixed a bug in the layer library where layers could be imported improperly in specific contexts.
+
 # v1.8.1 - 3 March 2021
 ## Fixes
 - Layer library should no longer throw errors when it encounters the "Network" and "PRE" platforms.

--- a/layers/exporters/svg_objects.py
+++ b/layers/exporters/svg_objects.py
@@ -260,7 +260,7 @@ class SVG_HeaderBlock:
             upper = G(tx=0, ty=2.1)
             internal.append(upper)
             if t1text is not None:
-                bu = t2text is not None and t2text is not ""
+                bu = t2text != None and t2text != ""
                 theight = (height-5)
                 if bu:
                     theight = theight / 2

--- a/layers/exporters/to_svg.py
+++ b/layers/exporters/to_svg.py
@@ -7,6 +7,8 @@ except ModuleNotFoundError:
     from ..core import Layer
     from ..exporters.svg_templates import SvgTemplates
 
+from layers.core import Layer as topLayer # alternative import for typechecking
+
 class NoLayer(Exception):
     pass
 
@@ -405,7 +407,7 @@ class ToSvg:
             :return: (meta) svg file at the targeted output location
         """
         if layer is not None:
-            if not isinstance(layer, Layer):
+            if not isinstance(layer, Layer) and not isinstance(layer, topLayer):
                 raise TypeError
 
         if layer is None:


### PR DESCRIPTION
Fixed issue where importing the Layer object in different ways could trick the system into thinking that the Layer object wasn't the Layer object. 