### PR TITLE
Initial support for detailed diff of changes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 antlr4-python3-runtime==4.8
 certifi==2020.12.5
 chardet==4.0.0
+dictdiffer==0.8.1
 idna==2.10
 python-dateutil==2.8.1
 pytz==2021.1


### PR DESCRIPTION
Initial commit of beta code for supporting detailed diff of ATT&CK changes.  I envision there will be additional refactoring required but wanted to give early access to the code in order to facilitate feedback.

Example invocation:
```
python3 diff_stix.py  -types technique -domains enterprise-attack -markdown --no-details x_mitre_platforms --no-details x_mitre_data_sources --no-details external_references --no-details x_mitre_contributors
```

@isaisabel