### PR TITLE
Feature/add datasources contribs diff stix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # v1.10.0 - 21 October 2021
 ## Improvements
-- [diff_stix.py](scripts/diff_stix.py) now supports an `--contributors` argument which adds a section listing contributors that contributed to the release.
+- [diff_stix.py](scripts/diff_stix.py) now supports a `--contributors` argument which adds a section listing contributors that contributed to the release.
 - [diff_stix.py](scripts/diff_stix.py) now supports data source and data components objects. A single section (Data Sources and/or Components) will track additions, modifications, deprecations, and revocations for these object types.
+- [diff_stix.py](scripts/diff_stix.py) now supports an `--use-mitre-cti` argument which downloads the MITRE CTI bundles for the old release comparison.
 
 # v1.9.2 - 25 June 2021
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [diff_stix.py](scripts/diff_stix.py) now supports a `--contributors` argument which adds a section listing contributors that contributed to the release.
 - [diff_stix.py](scripts/diff_stix.py) now supports data source and data components objects. A single section (Data Sources and/or Components) will track additions, modifications, deprecations, and revocations for these object types.
 - [diff_stix.py](scripts/diff_stix.py) now supports an `--use-mitre-cti` argument which downloads the MITRE CTI bundles for the old release comparison.
+- [diff_stix.py](scripts/diff_stix.py) now supports a `--create-html` argument which creates an HTML index page from the markdown of the changelog.
 
 # v1.9.2 - 25 June 2021
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-# 25 June 2021
-# v1.9.2
+# v1.9.2 - 25 June 2021
 ## Fixes
 - Patched list of data sources in [techniques_data_sources_vis.py](/scripts/techniques_data_sources_vis.py) and [techniques_from_Data_source.py](/scripts/techniques_from_Data_source.py) to use current data sources.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.10.0 - 21 October 2021
+## Improvements
+- [diff_stix.py](scripts/diff_stix.py) now supports an `--contributors` argument which adds a section listing contributors that contributed to the release.
+- [diff_stix.py](scripts/diff_stix.py) now supports data source and data components objects. A single section (Data Sources and/or Components) will track additions, modifications, deprecations, and revocations for these object types.
+
 # v1.9.2 - 25 June 2021
 ## Fixes
 - Patched list of data sources in [techniques_data_sources_vis.py](/scripts/techniques_data_sources_vis.py) and [techniques_from_Data_source.py](/scripts/techniques_from_Data_source.py) to use current data sources.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ antlr4-python3-runtime==4.8
 certifi==2020.12.5
 chardet==4.0.0
 idna==2.10
+markdown==2.6.11
 python-dateutil==2.8.1
 pytz==2021.1
 requests==2.25.1

--- a/scripts/diff_stix.py
+++ b/scripts/diff_stix.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 import datetime
 import requests
 import urllib3
+import markdown
 from string import Template
 from itertools import chain
 from dateutil import parser as dateparser
@@ -680,6 +681,32 @@ def markdown_string_to_file(outfile, content):
     verboseprint("done")
 
 
+def markdown_to_index_html(markdown_outfile, content):
+    """
+    Convert the markdown string passed in to HTML and store in index.html 
+    of indicated output file path
+    """
+
+    verboseprint("writing HTML to file... ", end="", flush="true")
+
+    # get output file path
+    outputfile_path = os.path.split(markdown_outfile)[0]
+    outfile = os.path.join(outputfile_path, "index.html")
+
+    # Center content
+    html_string = """<div style='max-width: 55em;margin: auto;margin-top:20px;font-family: "Roboto", sans-serif;'>"""
+    html_string += "<meta charset='utf-8'>"
+    html_string += "<h1 style='text-align:center;'>Changelog for the release</h1>"
+    html_string += markdown.markdown(content)
+    html_string += "</div>"
+
+    outfile = open(outfile, "w", encoding="utf-8")
+    outfile.write(html_string)
+    outfile.close()
+
+    verboseprint("done")
+
+
 def layers_dict_to_files(outfiles, layers):
     """
     Print the layers dict passed in to layer files.
@@ -752,6 +779,11 @@ if __name__ == '__main__':
         nargs="?",
         const=md_default, # default if no value specified
         help="create a markdown file reporting changes. If value is unspecified, defaults to %(const)s"
+    )
+
+    parser.add_argument("--create-html",
+        action="store_true",
+        help="create index.html page of markdown file that reported changes. Does not do anything unless -markdown is provided"
     )
     
     parser.add_argument("-layers",
@@ -849,6 +881,9 @@ if __name__ == '__main__':
     if args.markdown:
         md_string = diffStix.get_markdown_string()
         markdown_string_to_file(args.markdown, md_string)
+
+        if args.create_html:
+            markdown_to_index_html(args.markdown, md_string)
 
     if args.layers is not None:
         if len(args.layers) == 0:

--- a/scripts/diff_stix.py
+++ b/scripts/diff_stix.py
@@ -542,7 +542,7 @@ class DiffStix(object):
 
         def getContributorSection():
             # Get contributors markdown
-            contribSection = "#### Contributors to this release\n\n"
+            contribSection = "### Contributors to this release\n\n"
             sorted_contributors = sorted(self.data["new_contributors"])
 
             for contributor in sorted_contributors:
@@ -558,6 +558,10 @@ class DiffStix(object):
             if obj_type == "new_contributors": continue # Skip new contributors
             domains = ""
             for domain in self.data[obj_type]:
+                domains += f"**{domainToDomainLabel[domain]}**\n\n" # e.g "enterprise"
+                if domain == "mobile-attack" and obj_type == "datasource": 
+                    domains += "ATT&CK for Mobile does not support data sources\n\n"
+                    continue # Skip mobile sections for data sources
                 domain_sections = ""
                 for section in self.data[obj_type][domain]:
                     if len(self.data[obj_type][domain][section]) > 0: # if there are items in the section
@@ -572,7 +576,7 @@ class DiffStix(object):
                     if section_items == "No changes":
                         domain_sections += f"{header}\n{section_items}\n\n" # e.g "added techniques:"
                     else: domain_sections += f"{header}\n\n{section_items}\n\n" # add empty line between header and section list
-                domains += f"**{domainToDomainLabel[domain]}**\n\n{domain_sections}" # e.g "enterprise"
+                domains += f"{domain_sections}" # add domain sections
             content += f"### {attackTypeToTitle[obj_type]}\n\n{domains}" # e.g "techniques"
 
         if self.show_key:

--- a/scripts/diff_stix.py
+++ b/scripts/diff_stix.py
@@ -34,7 +34,7 @@ attackTypeToTitle = { # ATT&CK type to Title
     'mitigation': 'Mitigations',
     'datasource': 'Data Sources and/or Components'
 }
-attackTypeToSectionHeader = { # ATT&CK type to Title
+attackTypeToSectionName = { # ATT&CK type to section name
     'technique': 'Technique',
     'malware': 'Malware',
     'software': 'Software',
@@ -574,7 +574,7 @@ class DiffStix(object):
                     if "{obj_type}" in header:
                         if section == "additions":
                             header = header.replace("{obj_type}", attackTypeToTitle[obj_type])
-                        else: header = header.replace("{obj_type}", attackTypeToSectionHeader[obj_type])
+                        else: header = header.replace("{obj_type}", attackTypeToSectionName[obj_type])
                     if section_items == "No changes":
                         domain_sections += f"{header}\n{section_items}\n\n" # e.g "added techniques:"
                     else: domain_sections += f"{header}\n\n{section_items}\n\n" # add empty line between header and section list

--- a/scripts/diff_stix.py
+++ b/scripts/diff_stix.py
@@ -87,7 +87,8 @@ class DiffStix(object):
         site_prefix='',
         types=['technique', 'software', 'group', 'mitigation', 'datasource'],
         use_taxii=False,
-        verbose=False
+        verbose=False,
+        contributors=False
     ):
         """
         Construct a new 'DiffStix' object.
@@ -116,6 +117,7 @@ class DiffStix(object):
         self.types = types
         self.use_taxii = use_taxii
         self.verbose = verbose
+        self.contributors = contributors
 
         self.data = {   # data gets load into here in the load() function. All other functionalities rely on this data structure
             # technique {
@@ -583,8 +585,9 @@ class DiffStix(object):
             key_content = self.get_md_key()
             content = f"{key_content}\n\n{content}"
 
-        # Add contributors
-        content += getContributorSection()
+        # Add contributors if requested by argument
+        if self.contributors:
+            content += getContributorSection()
 
         self.verboseprint("done")
 
@@ -775,6 +778,11 @@ if __name__ == '__main__':
         action="store_true",
         help="Add a key explaining the change types to the markdown"
     )
+
+    parser.add_argument("--contributors",
+        action="store_true",
+        help="show new contributors between releases"
+    )
     
     args = parser.parse_args()
 
@@ -800,7 +808,8 @@ if __name__ == '__main__':
         site_prefix=args.site_prefix,
         types=args.types,
         use_taxii=args.use_taxii,
-        verbose=args.verbose
+        verbose=args.verbose,
+        contributors=args.contributors
     )
 
     if args.verbose:

--- a/scripts/diff_stix.py
+++ b/scripts/diff_stix.py
@@ -26,13 +26,21 @@ attackTypeToStixFilter = { # stix filters for querying for each type of data
     'datasource': [Filter('type', '=', 'x-mitre-data-source'), Filter('type', '=', 'x-mitre-data-component')],
     'datasource-only': [Filter('type', '=', 'x-mitre-data-source')] 
 }
-attackTypeToPlural = { # because some of these pluralize differently
-    'technique': 'techniques',
-    'malware': 'malware',
-    'software': 'software',
-    'group': 'groups',
-    'mitigation': 'mitigations',
-    'datasource': 'data sources'
+attackTypeToTitle = { # ATT&CK type to Title
+    'technique': 'Techniques',
+    'malware': 'Malware',
+    'software': 'Software',
+    'group': 'Groups',
+    'mitigation': 'Mitigations',
+    'datasource': 'Data Sources and/or Components'
+}
+attackTypeToSectionHeader = { # ATT&CK type to Title
+    'technique': 'Technique',
+    'malware': 'Malware',
+    'software': 'Software',
+    'group': 'Group',
+    'mitigation': 'Mitigation',
+    'datasource': 'Data Source and/or Component'
 }
 sectionNameToSectionHeaders = { # how we want to format headers for each section
     "additions": "New {obj_type}",
@@ -514,13 +522,13 @@ class DiffStix(object):
                     header = sectionNameToSectionHeaders[section] + ":"
                     if "{obj_type}" in header:
                         if section == "additions":
-                            header = header.replace("{obj_type}", attackTypeToPlural[obj_type].capitalize())
-                        else: header = header.replace("{obj_type}", obj_type.capitalize())
+                            header = header.replace("{obj_type}", attackTypeToTitle[obj_type])
+                        else: header = header.replace("{obj_type}", attackTypeToSectionHeader[obj_type])
                     if section_items == "No changes":
                         domain_sections += f"{header}\n{section_items}\n\n" # e.g "added techniques:"
                     else: domain_sections += f"{header}\n\n{section_items}\n\n" # add empty line between header and section list
                 domains += f"**{domainToDomainLabel[domain]}**\n\n{domain_sections}" # e.g "enterprise"
-            content += f"### {attackTypeToPlural[obj_type].capitalize()}\n\n{domains}" # e.g "techniques"
+            content += f"### {attackTypeToTitle[obj_type]}\n\n{domains}" # e.g "techniques"
 
         if self.show_key:
             key_content = self.get_md_key()

--- a/scripts/diff_stix.py
+++ b/scripts/diff_stix.py
@@ -293,6 +293,7 @@ class DiffStix(object):
                     collection = Collection("https://cti-taxii.mitre.org/stix/collections/" + domainToTaxiiCollectionId[domain])
                     data_store = TAXIICollectionSource(collection)
                     parse_subtechniques(data_store, new)
+                    parse_datacomponents(data_store, new)
                     return load_datastore(data_store)
 
                 if self.use_taxii:


### PR DESCRIPTION
PR to update `diff-stix.py` script to include data sources and contributors section when selecting markdown option.

New contributors are calculated as defined in #71 and script was tested for `If a contributor is removed from an object and (not re-added on a different object)`.

`data["new_contributors"]` will contain a dictionary of keys (names of contributors) and values (number of new contributions for the release) after the `load_data()` functions runs.

PR also adds new argument `--use-mitre-cti` that downloads the MITRE CTI bundles specified by the domains that may be used for the `old` comparison.

Closes #70, #71.